### PR TITLE
adding Reduce2One reducer function; bump version to fnlib:0.0.4

### DIFF
--- a/fnlib/build.gradle
+++ b/fnlib/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'org.ct42.fnflow'
-version = '0.0.3'
+version = '0.0.4'
 
 idea {
 	module {

--- a/fnlib/src/main/java/org/ct42/fnflow/fnlib/NullProperties.java
+++ b/fnlib/src/main/java/org/ct42/fnflow/fnlib/NullProperties.java
@@ -1,0 +1,7 @@
+package org.ct42.fnflow.fnlib;
+
+import lombok.Data;
+
+@Data
+public class NullProperties {
+}

--- a/fnlib/src/main/java/org/ct42/fnflow/fnlib/reducer/Reduce2One.java
+++ b/fnlib/src/main/java/org/ct42/fnflow/fnlib/reducer/Reduce2One.java
@@ -1,0 +1,29 @@
+package org.ct42.fnflow.fnlib.reducer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.ct42.fnflow.cfgfns.ConfigurableFunction;
+import org.ct42.fnflow.fnlib.NullProperties;
+import org.springframework.stereotype.Component;
+
+@Component("Reduce2One")
+public class Reduce2One extends ConfigurableFunction<JsonNode, JsonNode, NullProperties> {
+    @Override
+    public JsonNode apply(JsonNode input) {
+        JsonNode matches = input.get("matches");
+        if(matches == null || !matches.isArray()) {
+            throw new IllegalArgumentException("Invalid input, no matches array found");
+        }
+        if(matches.size() == 1) { // match
+            //leave everything as it is
+        } else if(matches.isEmpty()) { //no match
+            ((ArrayNode)matches).add(JsonNodeFactory.instance.objectNode());
+        } else { // ambiguous match
+            ((ObjectNode)input).replace("input", JsonNodeFactory.instance.nullNode());
+            ((ObjectNode)input).replace("matches", JsonNodeFactory.instance.arrayNode());
+        }
+        return input;
+    }
+}

--- a/fnlib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/fnlib/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 org.ct42.fnflow.fnlib.validator.hasvalue.HasValueValidator
 org.ct42.fnflow.fnlib.normalizer.trim.TrimNormalizer
 org.ct42.fnflow.fnlib.normalizer.pad.PadNormalizer
+org.ct42.fnflow.fnlib.reducer.Reduce2One

--- a/fnlib/src/test/java/org/ct42/fnflow/fnlibtest/reducer/Reduce2OneTest.java
+++ b/fnlib/src/test/java/org/ct42/fnflow/fnlibtest/reducer/Reduce2OneTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ct42.fnflow.fnlibtest.reducer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.function.context.FunctionCatalog;
+import org.springframework.context.annotation.ComponentScan;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+
+/**
+ * @author Claas Thiele
+ */
+@SpringBootTest(
+        properties = {
+                "cfgfns.Reduce2One.reduce.no-config" //if a function has no configuration, at least one property has to be provided, doesn't have to have a value
+        }
+)
+public class Reduce2OneTest {
+    @Autowired
+    FunctionCatalog catalog;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void testReduceOneMatch() throws Exception {
+        Function<JsonNode, JsonNode> function = catalog.lookup(Function.class, "reduce");
+        JsonNode input = mapper.readTree("""
+                {
+                    "input": {"id": "ID1"},
+                    "matches": [
+                        {"id": "match!", "score":1.0,"source":{"foo":"bar"}}
+                    ]
+                }""");
+
+        then(function.apply(input).toString()).isEqualTo("""
+                {"input":{"id":"ID1"},"matches":[{"id":"match!","score":1.0,"source":{"foo":"bar"}}]}""");
+    }
+
+    @Test
+    void testReduceOneAmbiguousMatch() throws Exception {
+        Function<JsonNode, JsonNode> function = catalog.lookup(Function.class, "reduce");
+        JsonNode input = mapper.readTree("""
+                {
+                    "input": {"id": "ID1"},
+                    "matches": [
+                        {"id": "match1", "score":1.0,"source":{"foo":"bar"}},
+                        {"id": "match2", "score":1.0,"source":{"foo":"baz"}}
+                    ]
+                }""");
+
+        then(function.apply(input).toString()).isEqualTo("""
+                {"input":null,"matches":[]}""");
+    }
+
+    @Test
+    void testReduceOneNoMatch() throws Exception {
+        Function<JsonNode, JsonNode> function = catalog.lookup(Function.class, "reduce");
+        JsonNode input = mapper.readTree("""
+                {
+                    "input": {"id": "ID1"},
+                    "matches": []
+                }""");
+
+        then(function.apply(input).toString()).isEqualTo("""
+                {"input":{"id":"ID1"},"matches":[{}]}""");
+    }
+
+    @Test
+    void testReduceOneNoMatchesArray() throws Exception {
+        Function<JsonNode, JsonNode> function = catalog.lookup(Function.class, "reduce");
+        JsonNode input = mapper.readTree("""
+                {
+                    "input": {"id": "ID1"}
+                }""");
+        thenThrownBy(() -> function.apply(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid input, no matches array found");
+    }
+
+    @Test
+    void testReduceOneMatchesOfWrongType() throws Exception {
+        Function<JsonNode, JsonNode> function = catalog.lookup(Function.class, "reduce");
+        JsonNode input = mapper.readTree("""
+                {
+                    "input": {"id": "ID1"},
+                    "matches": "I am wrong here!"
+                }""");
+        thenThrownBy(() -> function.apply(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid input, no matches array found");
+    }
+
+    @SpringBootApplication
+    @ComponentScan
+    protected static class ReducerTestApplication {}
+}


### PR DESCRIPTION

Having a ConfigurableFunction without any Config (as it is the case for Reduce2One) is abit tricky. 
1. We have to provide an empty Config object
2. In the configuration, there has to be at least one property, even if it has no value - a dummy property was put into the configuration. This can be hidden for the user later on by creating a dummy propety if the paramters are empty in the pipeline endpoint request 